### PR TITLE
Feat/srch-70: Helm Chart for Bouncer 1.2.0.

### DIFF
--- a/charts/bouncer/Chart.yaml
+++ b/charts/bouncer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.1.0
+appVersion: 1.2.0
 description: A Helm chart to deploy Bouncer
 home: https://github.com/lucidworks-managed-fusion/cloud-engineering-tooling
 keywords:
@@ -11,4 +11,4 @@ maintainers:
 name: bouncer
 sources:
   - https://github.com/lucidworks-managed-fusion/helm-charts.git
-version: 1.1.1
+version: 1.2.0

--- a/charts/bouncer/templates/cronjob.yaml
+++ b/charts/bouncer/templates/cronjob.yaml
@@ -34,4 +34,9 @@ spec:
                   value: {{ .Values.cronjob.bounce.job_launcher | quote }}
                 - name: "BOUNCER_BOUNCE_CLASSIC_REST_SERVICE"
                   value: {{ .Values.cronjob.bounce.classic_rest_service | quote }}
+                - name: "SERVICE_ACCOUNT_KEY"
+                  valueFrom:
+                    secretKeyRef:
+                      key: sa
+                      name: service-account-key
           restartPolicy: OnFailure

--- a/charts/bouncer/values.yaml
+++ b/charts/bouncer/values.yaml
@@ -10,7 +10,7 @@ cronjob:
   image:
     name: us-west1-docker.pkg.dev/managed-fusion/cloud-support/images/bouncer
     pullPolicy: Always
-    tag: 1.1.0
+    tag: 1.2.0
 
 imagePullSecrets:
   - name: gcr-managed-fusion


### PR DESCRIPTION
Bump Bouncer's version and Bouncer's Helm Chart's version to 1.2.0.  Map the service account key to an environment variable for Bouncer to pick up.