### PR TITLE
Adding feature flags

### DIFF
--- a/charts/collection-backups/Chart.yaml
+++ b/charts/collection-backups/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: collection-backups
 sources:
   - https://github.com/lucidworks-managed-fusion/helm-charts.git
-version: 0.2.11
+version: 0.2.20

--- a/charts/collection-backups/Chart.yaml
+++ b/charts/collection-backups/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: collection-backups
 sources:
   - https://github.com/lucidworks-managed-fusion/helm-charts.git
-version: 0.2.20
+version: 0.3.0

--- a/charts/collection-backups/templates/deployment.yaml
+++ b/charts/collection-backups/templates/deployment.yaml
@@ -8,11 +8,14 @@ metadata:
     {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-
-  {{- with .Values.annotations }}
   annotations:
+    {{- if .Values.featureFlags.enabled }}
+    openfeature.dev/enabled: "true"
+    openfeature.dev/featureflagsource: "{{ .Chart.Name }}-flags"
+    {{- end }}
+    {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/collection-backups/templates/featureflags.yaml
+++ b/charts/collection-backups/templates/featureflags.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.featureFlags.enabled }}
+apiVersion: core.openfeature.dev/v1beta1
+kind: FeatureFlagSource
+metadata:
+  name: {{ .Chart.Name }}-flags
+  labels:
+    app.kubernetes.io/name: {{ $.Chart.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: {{ $.Chart.Name }}
+spec:
+  sources:
+  {{- range .Values.featureFlags.flags }}
+    - source: {{ $.Chart.Name }}.{{ .name }}
+      provider: kubernetes
+  {{- end }}
+  port: 8080
+{{- range .Values.featureFlags.flags }}
+---
+apiVersion: core.openfeature.dev/v1beta1
+kind: FeatureFlag
+metadata:
+  name: {{ $.Chart.Name }}.{{ .name }}
+  labels:
+    app.kubernetes.io/name: {{ $.Chart.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: {{ $.Chart.Name }}
+  annotations:
+    featureflags/description: {{ .description | quote }}
+    featureflags/owner: {{ .owner }}
+spec:
+  flagSpec:
+    flags:
+      {{ .name }}:
+        state: {{ .state | quote }}
+        defaultVariant: {{ .defaultVariant | quote }}
+        variants:
+          {{ toJson .variants }}
+        {{- if .targeting }}
+        targeting:
+          {{ toJson .targeting }}
+        {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/collection-backups/values.yaml
+++ b/charts/collection-backups/values.yaml
@@ -23,7 +23,19 @@ solrXml:
   xmlFile: ""
 
 image:
-  repository: gcr.io/managed-fusion
+  repository: us-west1-docker.pkg.dev/managed-fusion/cloud-support/images
   name: collection-backups
-  tag: 1.3.0
+  tag: 1.4.0
   pullPolicy: Always
+
+featureFlags:
+  enabled: true  # Enable/disable all feature flags for this service
+  flags:
+    - name: backup.skip-backups # naming convention: <feature>.<attribute>
+      description: "Skips backups regardless of the schedule"
+      owner: "derek"
+      state: "ENABLED" # or "DISABLED"
+      defaultVariant: false
+      variants: # for boolean flags
+        true: true
+        false: false


### PR DESCRIPTION
This pull request introduces feature flag support to the `collection-backups` Helm chart and updates related configurations. The changes include the addition of feature flag templates, updates to annotations and metadata, and modifications to the image repository and versioning. Below is a breakdown of the most important changes:

### Feature Flag Support:

* **Added feature flag templates** in `charts/collection-backups/templates/featureflags.yaml` to define `FeatureFlagSource` and individual `FeatureFlag` resources, enabling feature flag management for the service.
* **Updated annotations** in `charts/collection-backups/templates/deployment.yaml` to include feature flag-related metadata when feature flags are enabled.

### Configuration Updates:

* **Added feature flag configurations** in `charts/collection-backups/values.yaml` to enable or disable feature flags and define specific flags with attributes like name, description, owner, state, and variants.

### Versioning and Repository Updates:

* **Updated Helm chart version** in `charts/collection-backups/Chart.yaml` from `0.2.11` to `0.3.0` to reflect the new feature additions.
* **Changed image repository and tag** in `charts/collection-backups/values.yaml` to use a new repository (`us-west1-docker.pkg.dev/managed-fusion/cloud-support/images`) and updated tag (`1.4.0`).