### PR TITLE
SRCH-808: Grant PRS configmap RBAC + bump to 0.4.0

### DIFF
--- a/charts/phantom-replica-service/Chart.yaml
+++ b/charts/phantom-replica-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.3.3
+appVersion: 0.4.0
 description: Helm chart for deploying the Phantom Replica Service
 home: https://github.com/lucidworks-managed-fusion/phantom-replica-deleter
 keywords:
@@ -15,4 +15,4 @@ name: phantom-replica-service
 sources:
   - https://github.com/lucidworks-managed-fusion/helm-charts.git
 type: application
-version: 1.0.5
+version: 1.0.6

--- a/charts/phantom-replica-service/templates/role.yaml
+++ b/charts/phantom-replica-service/templates/role.yaml
@@ -9,3 +9,7 @@ rules:
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create", "get"]
+  # SRCH-808: write per-run report to ConfigMap "prs-last-run" for fleet-wide aggregation.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update", "patch"]

--- a/charts/phantom-replica-service/values.yaml
+++ b/charts/phantom-replica-service/values.yaml
@@ -12,7 +12,7 @@ cronjob:
   image:
     name: us-west1-docker.pkg.dev/managed-fusion/cloud-support/images/phantom-replica-service
     pullPolicy: Always
-    tag: 0.3.3
+    tag: 0.4.0
 
 imagePullSecrets:
   - name: gcr-managed-fusion


### PR DESCRIPTION
## Summary

Companion to [phantom-replica-deleter#9](https://github.com/lucidworks-managed-fusion/phantom-replica-deleter/pull/9).

- `role.yaml`: add `configmaps` verbs (`get`, `create`, `update`, `patch`) so PRS can write its `prs-last-run` ConfigMap.
- `Chart.yaml`: `appVersion` 0.3.3 → 0.4.0, chart `version` 1.0.5 → 1.0.6 (matches existing patch-bump convention used in this chart, e.g. SRCH-668).
- `values.yaml`: image tag 0.3.3 → 0.4.0.

## Test plan

- [x] `helm lint charts/phantom-replica-service` passes.
- [x] `helm template` shows the new `configmaps` rule rendered correctly.
- [x] End-to-end tested in `stg` namespace on `lw-c-test-nodepool-non-prod-us-west1` with the 0.4.0 image — ConfigMap `prs-last-run` written with expected schema (see PR #9 for details).

> **Follow-up note (out of scope for SRCH-808):** the chart deployed to `stg` via `cloud-support-config` (chart 1.0.8 there) is missing `PHANTOMREPLICASERVICE_PIGDIRS_DELETE` / `PHANTOMREPLICASERVICE_PIGDIRS_OLDERTHANDAYS` env vars — Config.java has required them since SRCH-668, so PRS has been crashing on every scheduled run there. This canonical chart copy already has them. The `cloud-support-config` divergence should be reconciled separately.

## Jira

[SRCH-808](https://lucidworks.atlassian.net/browse/SRCH-808)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SRCH-808]: https://lucidworks.atlassian.net/browse/SRCH-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ