### PR TITLE
SRCH-897: add fusion-datasource-monitor chart

### DIFF
--- a/charts/fusion-datasource-monitor/.helmignore
+++ b/charts/fusion-datasource-monitor/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+.github
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+*.old
+*.xml

--- a/charts/fusion-datasource-monitor/Chart.yaml
+++ b/charts/fusion-datasource-monitor/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+appVersion: 0.1.0
+description: A Helm chart to deploy the Fusion datasource job-status monitor/exporter
+home: https://github.com/lucidworks-managed-fusion/cloud-engineering-tooling.git
+keywords:
+  - fusion
+  - datasource
+  - solr
+  - lucidworks
+  - monitoring
+maintainers:
+  - email: duane.rackley@lucidworks.com
+    name: Duane Rackley
+    url: https://github.com/lucidworks-managed-fusion/helm-charts
+name: fusion-datasource-monitor
+sources:
+  - https://github.com/lucidworks-managed-fusion/helm-charts.git
+version: 0.1.0

--- a/charts/fusion-datasource-monitor/templates/_helpers.tpl
+++ b/charts/fusion-datasource-monitor/templates/_helpers.tpl
@@ -1,0 +1,100 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fusion-datasource-monitor.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fusion-datasource-monitor.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified host name for zookeeper.
+*/}}
+{{- define "fusion-datasource-monitor.zookeeperHost" -}}
+{{- if .Values.zookeeperHost -}}
+{{- .Values.zookeeperHost | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name "zookeeper" -}}
+{{- printf "%s-%s-headless.%s:2181" .Release.Name $name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Fusion app name label - defaults to the release namespace, same pattern as
+collection-backups.customerId.
+*/}}
+{{- define "fusion-datasource-monitor.appName" -}}
+{{- if .Values.appName -}}
+{{- .Values.appName | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{ include "fusion-datasource-monitor.namespace" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fusion-datasource-monitor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fusion-datasource-monitor.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fusion-datasource-monitor.name" . }}
+app.kubernetes.io/instance: {{ include "fusion-datasource-monitor.fullname" . }}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "fusion-datasource-monitor.labels" -}}
+helm.sh/chart: {{ include "fusion-datasource-monitor.chart" . }}
+{{ include "fusion-datasource-monitor.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/revision: {{ .Release.Revision | quote }}
+release: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fusion-datasource-monitor.serviceAccountName" -}}
+  {{ default (include "fusion-datasource-monitor.fullname" .) .Values.serviceAccount.name }}
+{{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "fusion-datasource-monitor.namespace" -}}
+  {{- if .Values.global -}}
+    {{- if .Values.global.namespaceOverride -}}
+      {{- .Values.global.namespaceOverride -}}
+    {{- else -}}
+      {{- .Release.Namespace -}}
+    {{- end -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/fusion-datasource-monitor/templates/deployment.yaml
+++ b/charts/fusion-datasource-monitor/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "fusion-datasource-monitor.labels" . | nindent 6 }}
+      {{- include "fusion-datasource-monitor.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:

--- a/charts/fusion-datasource-monitor/templates/deployment.yaml
+++ b/charts/fusion-datasource-monitor/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "fusion-datasource-monitor.fullname" . }}
+  namespace: {{ template "fusion-datasource-monitor.namespace" . }}
+  labels:
+    {{- include "fusion-datasource-monitor.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "fusion-datasource-monitor.labels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+      {{- with .Values.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "fusion-datasource-monitor.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "fusion-datasource-monitor.serviceAccountName" . }}
+      securityContext:
+          {{- toYaml .Values.securityContext | nindent 8 }}
+          {{- with .Values.nodeSelector }}
+      nodeSelector:
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+      containers:
+        - name: fusion-datasource-monitor
+          image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: FUSION_APP_NAME
+              value: {{ template "fusion-datasource-monitor.appName" . }}
+            - name: DATASOURCE_MONITOR_ZK_HOST
+              value: {{ template "fusion-datasource-monitor.zookeeperHost" . }}
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/fusion-datasource-monitor/templates/service.yaml
+++ b/charts/fusion-datasource-monitor/templates/service.yaml
@@ -9,7 +9,7 @@ metadata:
     prometheus.io/scrape: "true"
 spec:
   selector:
-    {{- include "fusion-datasource-monitor.labels" . | nindent 4 }}
+    {{- include "fusion-datasource-monitor.selectorLabels" . | nindent 4 }}
   ports:
     - name: http
       protocol: TCP

--- a/charts/fusion-datasource-monitor/templates/service.yaml
+++ b/charts/fusion-datasource-monitor/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fusion-datasource-monitor.fullname" . }}
+  namespace: {{ template "fusion-datasource-monitor.namespace" . }}
+  annotations:
+    prometheus.io/path: "/actuator/prometheus"
+    prometheus.io/port: "8080"
+    prometheus.io/scrape: "true"
+spec:
+  selector:
+    {{- include "fusion-datasource-monitor.labels" . | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/charts/fusion-datasource-monitor/templates/serviceaccount.yaml
+++ b/charts/fusion-datasource-monitor/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fusion-datasource-monitor.serviceAccountName" . }}
+  namespace: {{ template "fusion-datasource-monitor.namespace" . }}
+  labels:
+    {{- include "fusion-datasource-monitor.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/fusion-datasource-monitor/values.yaml
+++ b/charts/fusion-datasource-monitor/values.yaml
@@ -8,10 +8,15 @@ zookeeperHost:
 appName:
 
 # solr.collection, solr.connect-timeout-secs, and poll.fixed-delay-ms are NOT exposed here -
-# DatasourceMonitorSettings only binds zk-host/namespace/app to env vars
-# (DATASOURCE_MONITOR_ZK_HOST/POD_NAMESPACE/FUSION_APP_NAME); the other properties are
-# hardcoded in application.properties with no env var override today. Exposing chart values
-# for them would be misleading until the app itself supports overriding them.
+# this chart's deployment.yaml only wires zk-host/namespace/app through to env vars
+# (DATASOURCE_MONITOR_ZK_HOST/POD_NAMESPACE/FUSION_APP_NAME), with no extraEnv/passthrough
+# mechanism for the others. Exposing chart values for them would be misleading until the
+# chart itself adds that wiring.
+#
+# Deployment topology: this chart deploys one pod per Fusion namespace (not a central
+# per-cluster poller) - a deliberate decision, not a default. See
+# https://github.com/lucidworks-managed-fusion/cloud-engineering-tooling/pull/147 for the
+# rationale (the exporter's Java runtime only supports one ZK host/namespace per process).
 
 nodeSelector: {}
 securityContext: {}

--- a/charts/fusion-datasource-monitor/values.yaml
+++ b/charts/fusion-datasource-monitor/values.yaml
@@ -1,0 +1,45 @@
+# Zookeeper connection string for the SolrCloud cluster hosting system_jobs_history.
+# Defaults to "<release>-zookeeper-headless.<namespace>:2181" (same computed-default pattern
+# as the collection-backups chart) if not set explicitly.
+zookeeperHost:
+
+# Fusion app name label applied to fusion_datasource_job_last_status series.
+# Defaults to the release namespace (same pattern as collection-backups.customerId) if not set.
+appName:
+
+# solr.collection, solr.connect-timeout-secs, and poll.fixed-delay-ms are NOT exposed here -
+# DatasourceMonitorSettings only binds zk-host/namespace/app to env vars
+# (DATASOURCE_MONITOR_ZK_HOST/POD_NAMESPACE/FUSION_APP_NAME); the other properties are
+# hardcoded in application.properties with no env var override today. Exposing chart values
+# for them would be misleading until the app itself supports overriding them.
+
+nodeSelector: {}
+securityContext: {}
+annotations: {}
+labels: {}
+imagePullSecrets: []
+
+# Service Account configuration
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  # If not set and create is false, defaults to "default"
+  name: ""
+  annotations: {}
+
+resources:
+  # -Xmx2g/-Xms2g (the exporter's jib jvmFlags) + headroom for metaspace/threads/off-heap.
+  requests:
+    cpu: 250m
+    memory: 2560Mi
+  limits:
+    cpu: 500m
+    memory: 3Gi
+
+image:
+  repository: us-docker.pkg.dev/managed-fusion/engineering-tooling-images
+  name: fusion-datasource-monitor
+  tag: 0.1.0
+  pullPolicy: Always


### PR DESCRIPTION
## Summary
Packages the `fusion-datasource-monitor` exporter ([SRCH-893](https://lucidworks.atlassian.net/browse/SRCH-893)) as a published Helm chart, following `collection-backups`' exact conventions as the model to mirror:

- `_helpers.tpl`: same `name`/`fullname`/`namespace` pattern, and the same computed-default `zookeeperHost` (`<release>-zookeeper-headless.<namespace>:2181`, overridable via `.Values.zookeeperHost`) that `collection-backups.zookeeperHost` uses.
- GMP scraping via plain `prometheus.io/scrape`, `prometheus.io/port`, `prometheus.io/path` annotations on the Service — matching `collection-backups`' `apiservice.yaml`, not a PodMonitoring CR (there's no PodMonitoring anywhere else in this chart repo).
- Image registry: `us-docker.pkg.dev/managed-fusion/engineering-tooling-images`, matching `collection-backups`' own convention (there were 3 different conventions across sibling modules in `cloud-engineering-tooling` — went with this one since we're explicitly matching `collection-backups`).

**Deliberately not exposed as chart values:** `solr.collection`, `solr.connect-timeout-secs`, `poll.fixed-delay-ms` — the exporter's `DatasourceMonitorSettings` only binds `zk-host`/`namespace`/`app` to env vars today; the others are hardcoded in `application.properties` with no override mechanism, so exposing chart values for them would be misleading.

**Why this exists / supersedes PR #147's k8s manifest:** SRCH-897 originally shipped a static Deployment/Service/PodMonitoring YAML meant for manual `kubectl apply`. Checking Amex's non-prod `dev` ArgoCD Application found `syncPolicy.automated: {prune: true, selfHeal: true}` — anything applied outside the tracked Helm release there gets deleted/reverted on the next sync. A real deployment needs to be a tracked chart dependency, same as `collection-backups` already is.

**Validated:**
- `helm lint charts/fusion-datasource-monitor` — 0 failures (1 info: no icon).
- `helm template` with defaults renders correctly — `FUSION_APP_NAME` defaults to the namespace, `DATASOURCE_MONITOR_ZK_HOST` computes to `<release>-zookeeper-headless.<namespace>:2181`, matching the real ZK convention confirmed against Amex's `dev` namespace's actual `zookeeper.connect-string`.

## Not done here (follow-ups)
- The Docker image itself still needs to actually be built and pushed to `us-docker.pkg.dev/managed-fusion/engineering-tooling-images/fusion-datasource-monitor:0.1.0` — no CI publishes it yet.
- `cloud-engineering-tooling`'s `fusion-datasource-monitor/build.gradle` jib target currently points at a different registry (`us-west1-docker.pkg.dev/managed-fusion/cloud-support/images/...`) — needs updating to match this chart's `image.repository`/`image.name`, or this chart's values need updating to match wherever the image actually ends up. Flagging rather than silently picking one.
- Wiring this chart in as an actual dependency in `amex-config`'s `Chart.yaml` (the way `collection-backups` is wired in) is a separate PR against that repo.

## Test plan
- [ ] `helm lint` / `helm template` (done above)
- [ ] Confirm chart-releaser publishes this correctly once merged (same automation `collection-backups` uses)
- [ ] Resolve the image registry mismatch before this chart is actually usable end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SRCH-893]: https://lucidworks.atlassian.net/browse/SRCH-893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ