### PR TITLE
Fix fusion-datasource-monitor serviceAccountName when create=false

### DIFF
--- a/charts/fusion-datasource-monitor/Chart.yaml
+++ b/charts/fusion-datasource-monitor/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: fusion-datasource-monitor
 sources:
   - https://github.com/lucidworks-managed-fusion/helm-charts.git
-version: 0.1.0
+version: 0.1.1

--- a/charts/fusion-datasource-monitor/templates/_helpers.tpl
+++ b/charts/fusion-datasource-monitor/templates/_helpers.tpl
@@ -81,7 +81,11 @@ release: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "fusion-datasource-monitor.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
   {{ default (include "fusion-datasource-monitor.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+  {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## Summary
Deployment-blocking bug found on the chart's first real deployment ([lw-docs-config#291](https://github.com/lucidworks-managed-fusion/lw-docs-config/pull/291), `dev` namespace):

```
Error creating: pods "..." is forbidden: error looking up service account
dev/dev-fusion-datasource-monitor: serviceaccount "dev-fusion-datasource-monitor" not found
```

`fusion-datasource-monitor.serviceAccountName` always resolved to the chart's fullname regardless of `.Values.serviceAccount.create`, but `templates/serviceaccount.yaml` only creates that object when `create: true`. With the chart's default (`create: false`), the Deployment referenced a ServiceAccount that never existed — every pod creation failed immediately, 0/1 replicas.

Fix: fall back to `"default"` when `create` is false, matching what `values.yaml`'s own comment already documented as the intended behavior. Bumped to `0.1.1` since `0.1.0` is already published.

**Note:** the identical bug exists in `collection-backups` (this chart copied its `_helpers.tpl` verbatim) — not fixed here since it's out of scope for this chart, but worth someone checking whether it's silently relying on always setting `create: true` or an explicit name in every consuming repo.

## Test plan
- [x] `helm lint` — 0 failures
- [x] `helm template` with default values → `serviceAccountName: default`
- [x] `helm template --set serviceAccount.create=true` → `serviceAccountName: <fullname>`
- [ ] Re-sync `lw-docs-config`'s `dev` app once this is published and the dependency version bumped, confirm the pod actually comes up healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)