### PR TITLE
fusion-datasource-monitor: add PodMonitoring for GMP scraping

### DIFF
--- a/charts/fusion-datasource-monitor/Chart.yaml
+++ b/charts/fusion-datasource-monitor/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: fusion-datasource-monitor
 sources:
   - https://github.com/lucidworks-managed-fusion/helm-charts.git
-version: 0.1.1
+version: 0.1.2

--- a/charts/fusion-datasource-monitor/templates/podmonitoring.yaml
+++ b/charts/fusion-datasource-monitor/templates/podmonitoring.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ template "fusion-datasource-monitor.fullname" . }}
+  namespace: {{ template "fusion-datasource-monitor.namespace" . }}
+  labels:
+    {{- include "fusion-datasource-monitor.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "fusion-datasource-monitor.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /actuator/prometheus
+      interval: 30s
+      metricRelabeling:
+        - action: keep
+          sourceLabels: ["__name__"]
+          regex: fusion_datasource_job_(last_status|runs_total|last_run_timestamp)
+  targetLabels:
+    metadata:
+      - pod
+      - container
+      - top_level_controller_name
+      - top_level_controller_type


### PR DESCRIPTION
## Summary
Found while validating this chart's data actually reaches a dashboard/alerts on the `lw-docs-config` test cluster: this chart relied on `prometheus.io/*` Service annotations (copied from `collection-backups`), but confirmed this cluster's actual GMP setup doesn't use annotation-based discovery at all — every real scrape target (`solr-prometheus-exporter`, `prd-alt-data-sync`, `config-sync`, etc.) uses an explicit `PodMonitoring`/`ClusterPodMonitoring` CRD. Checked: `collection-backups` has no monitoring resource anywhere on this cluster either — its annotations are equally inert. So the pattern this chart copied was never actually working infrastructure, just leftover boilerplate.

Adds a namespaced `PodMonitoring`, modeled directly on `prd-alt-data-sync` (an actively-scraped Spring Boot app on this same cluster, confirmed `health: up` in its status, same `/actuator/prometheus` path):
- Selects on the chart's stable `selectorLabels` (name + instance — not the full volatile label set, same reasoning as the earlier selector-immutability fix in #54)
- Scrapes port 8080 every 30s
- `metricRelabeling` keeps only this module's own metrics (`fusion_datasource_job_*`), matching the platform convention of not scraping default JVM/actuator noise

Bumped to `0.1.2`. Left the existing `prometheus.io/*` annotations in place — harmless, not touching them as part of this fix.

## Test plan
- [x] `helm lint` — 0 failures
- [x] `helm template` renders the `PodMonitoring` correctly
- [ ] Once published and bumped in `lw-docs-config`, confirm `kubectl get podmonitoring` shows `ConfigurationCreateSuccess` and an active target, and that the metrics actually show up in Grafana via the `managed-prometheus` datasource

🤖 Generated with [Claude Code](https://claude.com/claude-code)