### PR TITLE
fusion-datasource-monitor: add namespaced Rules for SRCH-895 alerts

### DIFF
--- a/charts/fusion-datasource-monitor/Chart.yaml
+++ b/charts/fusion-datasource-monitor/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: fusion-datasource-monitor
 sources:
   - https://github.com/lucidworks-managed-fusion/helm-charts.git
-version: 0.1.2
+version: 0.1.3

--- a/charts/fusion-datasource-monitor/templates/rules.yaml
+++ b/charts/fusion-datasource-monitor/templates/rules.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.alerts.enabled }}
+apiVersion: monitoring.googleapis.com/v1
+kind: Rules
+metadata:
+  name: {{ template "fusion-datasource-monitor.fullname" . }}
+  namespace: {{ template "fusion-datasource-monitor.namespace" . }}
+  labels:
+    {{- include "fusion-datasource-monitor.labels" . | nindent 4 }}
+spec:
+  groups:
+    - name: fusion-datasource-monitor-alerts
+      rules:
+        - alert: FusionDatasourceJobFailed
+          expr: |
+            (
+              increase(fusion_datasource_job_runs_total{status="FAILED"}[{{ .Values.alerts.ops.failureWindow }}]) >= {{ .Values.alerts.ops.failureCount }}
+            )
+            and
+            (
+              increase(fusion_datasource_job_runs_total{status="SUCCESS"}[{{ .Values.alerts.ops.failureWindow }}]) == 0
+            )
+          for: 5m
+          labels:
+            severity: warning
+            routing_tier: ops
+            customer: '{{`{{ $labels.namespace }}`}}'
+          annotations:
+            summary: "Fusion datasource {{`{{ $labels.datasource }}`}} has failed repeatedly"
+            description: "Datasource {{`{{ $labels.datasource }}`}} has at least {{ .Values.alerts.ops.failureCount }} failed runs and no successful run in the last {{ .Values.alerts.ops.failureWindow }}. Auto-resolves on the next successful run."
+
+        - alert: FusionDatasourceJobFailedSustained
+          expr: |
+            (
+              increase(fusion_datasource_job_runs_total{status="FAILED"}[{{ .Values.alerts.client.failureWindow }}]) >= {{ .Values.alerts.client.failureCount }}
+            )
+            and
+            (
+              increase(fusion_datasource_job_runs_total{status="SUCCESS"}[{{ .Values.alerts.client.failureWindow }}]) == 0
+            )
+          for: 5m
+          labels:
+            severity: critical
+            routing_tier: client
+            customer: '{{`{{ $labels.namespace }}`}}'
+          annotations:
+            summary: "Fusion datasource {{`{{ $labels.datasource }}`}} has failed repeatedly (sustained)"
+            description: "Datasource {{`{{ $labels.datasource }}`}} has at least {{ .Values.alerts.client.failureCount }} failed runs and no successful run in the last {{ .Values.alerts.client.failureWindow }}. Escalated to the client tier. Auto-resolves on the next successful run."
+
+        - alert: FusionDatasourceJobStale
+          expr: time() - fusion_datasource_job_last_run_timestamp > {{ .Values.alerts.ops.staleWindowSeconds }}
+          for: 5m
+          labels:
+            severity: warning
+            routing_tier: ops
+            customer: '{{`{{ $labels.namespace }}`}}'
+          annotations:
+            summary: "Fusion datasource {{`{{ $labels.datasource }}`}} has not run recently"
+            description: "Datasource {{`{{ $labels.datasource }}`}} has no recorded run (successful or failed) in over {{ .Values.alerts.ops.staleWindowSeconds }}s - it may have stopped being scheduled, or may never have run at all."
+
+        - alert: FusionDatasourceJobStaleSustained
+          expr: time() - fusion_datasource_job_last_run_timestamp > {{ .Values.alerts.client.staleWindowSeconds }}
+          for: 5m
+          labels:
+            severity: critical
+            routing_tier: client
+            customer: '{{`{{ $labels.namespace }}`}}'
+          annotations:
+            summary: "Fusion datasource {{`{{ $labels.datasource }}`}} has not run in over {{ .Values.alerts.client.staleWindowSeconds }}s"
+            description: "Datasource {{`{{ $labels.datasource }}`}} has no recorded run (successful or failed) in over {{ .Values.alerts.client.staleWindowSeconds }}s. Escalated to the client tier."
+{{- end }}

--- a/charts/fusion-datasource-monitor/values.yaml
+++ b/charts/fusion-datasource-monitor/values.yaml
@@ -48,3 +48,22 @@ image:
   name: fusion-datasource-monitor
   tag: 0.1.0
   pullPolicy: Always
+
+# Namespaced GMP Rules (PrometheusRule-equivalent) alerting over this exporter's metrics
+# (SRCH-895). Off by default - the thresholds below are provisional defaults from
+# Meychele's PRIN-1018 note, not yet product-confirmed per customer (see SRCH-902 for
+# Amex's). Override per-customer in that customer's own values file rather than editing
+# this chart, since different customers may confirm different thresholds.
+alerts:
+  enabled: false
+  ops:
+    failureCount: 2
+    failureWindow: 48h
+    # Same threshold as failureWindow, expressed in seconds - required because GMP/Prometheus
+    # duration literals (e.g. "24h") are only valid inside a range vector selector ([24h]),
+    # not in a scalar comparison like `time() - x > N`.
+    staleWindowSeconds: 86400 # 24h
+  client:
+    failureCount: 4
+    failureWindow: 8d
+    staleWindowSeconds: 259200 # 72h


### PR DESCRIPTION
## Summary
- Adds `templates/rules.yaml`, wrapping the SRCH-895 `datasource-alerts.yaml` alert groups in a namespaced GMP `Rules` CRD. Namespaced `Rules` scope automatically to the release namespace and don't touch the shared cluster-wide `ClusterRules`/`GlobalRules` resources used for per-cluster production alerting — same additive, isolated pattern as the `PodMonitoring` addition in #55.
- Gated behind `alerts.enabled` (default `false`) — the failure/staleness thresholds are still provisional pending per-customer product confirmation (SRCH-902 for Amex).
- Thresholds (`failureCount`/`failureWindow`/`staleWindowSeconds` for both `ops` and `client` tiers) are exposed as values with today's PRIN-1018 defaults, rather than hardcoded in the template, so future customers can override them without forking the chart.

Bumps chart version 0.1.2 → 0.1.3.

## Test plan
- [x] `helm lint .` passes
- [x] `helm template . --set alerts.enabled=false` (default) renders no `Rules` object
- [x] `helm template . --set alerts.enabled=true` renders a valid `Rules` object with correct PromQL templating (`{{ $labels.* }}` escapes correctly)
- [ ] Enable on `lw-docs-config` test cluster (dev namespace, non-customer) and confirm the `Rules` object loads without evaluation errors against real exporter data