### PR TITLE
fusion-datasource-monitor: add required interval to Rules group

### DIFF
--- a/charts/fusion-datasource-monitor/Chart.yaml
+++ b/charts/fusion-datasource-monitor/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: fusion-datasource-monitor
 sources:
   - https://github.com/lucidworks-managed-fusion/helm-charts.git
-version: 0.1.3
+version: 0.1.4

--- a/charts/fusion-datasource-monitor/templates/rules.yaml
+++ b/charts/fusion-datasource-monitor/templates/rules.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   groups:
     - name: fusion-datasource-monitor-alerts
+      interval: 1m
       rules:
         - alert: FusionDatasourceJobFailed
           expr: |


### PR DESCRIPTION
## Summary
- Fixes #56: GMP's `Rules` CRD requires `spec.groups[].interval` (unlike `PodMonitoring`, which has none). Discovered live applying `alerts.enabled=true` to the `lw-docs-config` test cluster: `Rules.monitoring.googleapis.com "dev-fusion-datasource-monitor" is invalid: spec.groups[0].interval: Required value`.
- Sets `interval: 1m` for the alert group.

Bumps chart version 0.1.3 → 0.1.4.

## Test plan
- [x] `helm lint .` passes
- [x] `helm template . --set alerts.enabled=true` renders `interval: 1m` in the group
- [ ] Re-apply on `lw-docs-config` test cluster and confirm the `Rules` object is accepted