### PR TITLE
fusion-datasource-monitor: aggregate + tier alerts, fix never-fires and() bug

### DIFF
--- a/charts/fusion-datasource-monitor/Chart.yaml
+++ b/charts/fusion-datasource-monitor/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: fusion-datasource-monitor
 sources:
   - https://github.com/lucidworks-managed-fusion/helm-charts.git
-version: 0.1.4
+version: 0.1.5

--- a/charts/fusion-datasource-monitor/templates/rules.yaml
+++ b/charts/fusion-datasource-monitor/templates/rules.yaml
@@ -11,61 +11,49 @@ spec:
     - name: fusion-datasource-monitor-alerts
       interval: 1m
       rules:
-        - alert: FusionDatasourceJobFailed
+        # One alert per namespace (not per datasource, not per condition) - fires only when at
+        # least one datasource in the namespace is in a critical state. The message embeds both
+        # the critical datasources and any additional non-critical ones currently affected, so
+        # ops gets the full picture in a single notification instead of a flood of individual
+        # per-datasource alerts.
+        #
+        # "Critical" = sustained failure (>= client.failureCount failed runs, no success, in
+        # client.failureWindow) OR fully stale (no run at all in client.staleWindowSeconds).
+        # "Non-critical" = the same conditions at the looser ops thresholds, MINUS anything
+        # already counted as critical (so a datasource never appears in both lists).
+        #
+        # NOTE: annotations cannot reference each other (Prometheus's annotation template
+        # context has no access to sibling annotations - confirmed via promtool, not assumed),
+        # so the critical/non-critical detail is duplicated directly in `description` itself,
+        # since that's the field the shared Alertmanager Slack template actually renders.
+        #
+        # NOTE: `and on (namespace, datasource)` is required, not optional decoration - PromQL's
+        # `and`/`unless` match on the FULL label set by default, and the FAILED/SUCCESS sides of
+        # this comparison differ on `status`, so a bare `and` NEVER matches (confirmed via
+        # promtool: the original per-datasource FusionDatasourceJobFailed/FailedSustained alerts
+        # shipped in 0.1.3/0.1.4 had this same bug and could never fire, on any cluster - this
+        # went unnoticed because live validation only ever exercised the Stale family, which
+        # doesn't have this issue).
+        - alert: FusionDatasourceCriticalIssue
           expr: |
-            (
-              increase(fusion_datasource_job_runs_total{status="FAILED"}[{{ .Values.alerts.ops.failureWindow }}]) >= {{ .Values.alerts.ops.failureCount }}
-            )
-            and
-            (
-              increase(fusion_datasource_job_runs_total{status="SUCCESS"}[{{ .Values.alerts.ops.failureWindow }}]) == 0
-            )
-          for: 5m
-          labels:
-            severity: warning
-            routing_tier: ops
-            customer: '{{`{{ $labels.namespace }}`}}'
-          annotations:
-            summary: "Fusion datasource {{`{{ $labels.datasource }}`}} has failed repeatedly"
-            description: "Datasource {{`{{ $labels.datasource }}`}} has at least {{ .Values.alerts.ops.failureCount }} failed runs and no successful run in the last {{ .Values.alerts.ops.failureWindow }}. Auto-resolves on the next successful run."
-
-        - alert: FusionDatasourceJobFailedSustained
-          expr: |
-            (
-              increase(fusion_datasource_job_runs_total{status="FAILED"}[{{ .Values.alerts.client.failureWindow }}]) >= {{ .Values.alerts.client.failureCount }}
-            )
-            and
-            (
-              increase(fusion_datasource_job_runs_total{status="SUCCESS"}[{{ .Values.alerts.client.failureWindow }}]) == 0
-            )
+            count by (namespace) (
+              count by (namespace, datasource) (
+                increase(fusion_datasource_job_runs_total{status="FAILED"}[{{ .Values.alerts.client.failureWindow }}]) >= {{ .Values.alerts.client.failureCount }}
+                and on (namespace, datasource)
+                increase(fusion_datasource_job_runs_total{status="SUCCESS"}[{{ .Values.alerts.client.failureWindow }}]) == 0
+              )
+              or
+              count by (namespace, datasource) (
+                time() - fusion_datasource_job_last_run_timestamp > {{ .Values.alerts.client.staleWindowSeconds }}
+              )
+            ) > 0
           for: 5m
           labels:
             severity: critical
-            routing_tier: client
             customer: '{{`{{ $labels.namespace }}`}}'
           annotations:
-            summary: "Fusion datasource {{`{{ $labels.datasource }}`}} has failed repeatedly (sustained)"
-            description: "Datasource {{`{{ $labels.datasource }}`}} has at least {{ .Values.alerts.client.failureCount }} failed runs and no successful run in the last {{ .Values.alerts.client.failureWindow }}. Escalated to the client tier. Auto-resolves on the next successful run."
-
-        - alert: FusionDatasourceJobStale
-          expr: time() - fusion_datasource_job_last_run_timestamp > {{ .Values.alerts.ops.staleWindowSeconds }}
-          for: 5m
-          labels:
-            severity: warning
-            routing_tier: ops
-            customer: '{{`{{ $labels.namespace }}`}}'
-          annotations:
-            summary: "Fusion datasource {{`{{ $labels.datasource }}`}} has not run recently"
-            description: "Datasource {{`{{ $labels.datasource }}`}} has no recorded run (successful or failed) in over {{ .Values.alerts.ops.staleWindowSeconds }}s - it may have stopped being scheduled, or may never have run at all."
-
-        - alert: FusionDatasourceJobStaleSustained
-          expr: time() - fusion_datasource_job_last_run_timestamp > {{ .Values.alerts.client.staleWindowSeconds }}
-          for: 5m
-          labels:
-            severity: critical
-            routing_tier: client
-            customer: '{{`{{ $labels.namespace }}`}}'
-          annotations:
-            summary: "Fusion datasource {{`{{ $labels.datasource }}`}} has not run in over {{ .Values.alerts.client.staleWindowSeconds }}s"
-            description: "Datasource {{`{{ $labels.datasource }}`}} has no recorded run (successful or failed) in over {{ .Values.alerts.client.staleWindowSeconds }}s. Escalated to the client tier."
+            summary: "{{`{{ $labels.namespace }}`}} has {{`{{ $value }}`}} datasource(s) in a critical state"
+            description: >-
+              {{`Critical: {{ range query (printf "count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) >= `}}{{ .Values.alerts.client.failureCount }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.client.staleWindowSeconds }}{{`)" $labels.namespace) }}{{ .Labels.datasource }}, {{ end }}`}}
+              {{`Also currently failing (non-critical): {{ range query (printf "(count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.ops.failureWindow }}{{`]) >= `}}{{ .Values.alerts.ops.failureCount }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.ops.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.ops.staleWindowSeconds }}{{`)) unless (count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) >= `}}{{ .Values.alerts.client.failureCount }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.client.staleWindowSeconds }}{{`))" $labels.namespace) }}{{ .Labels.datasource }}, {{ end }}`}}
 {{- end }}

--- a/charts/fusion-datasource-monitor/templates/rules.yaml
+++ b/charts/fusion-datasource-monitor/templates/rules.yaml
@@ -34,7 +34,13 @@ spec:
         # shipped in 0.1.3/0.1.4 had this same bug and could never fire, on any cluster - this
         # went unnoticed because live validation only ever exercised the Stale family, which
         # doesn't have this issue).
-        - alert: FusionDatasourceCriticalIssue
+        # Named FusionDatasourceJob* (not just "FusionDatasourceCriticalIssue") deliberately -
+        # the shared Alertmanager route (SRCH-896) matches `alertname: 'FusionDatasourceJob.*'`,
+        # an ANCHORED regex requiring the name to start with "FusionDatasourceJob". Anything else
+        # falls through to the default Rootly webhook receiver - the exact failure mode that
+        # caused the original incident this epic already had. Verify this route still matches
+        # before ever renaming this alert again.
+        - alert: FusionDatasourceJobCriticalIssue
           expr: |
             count by (namespace) (
               count by (namespace, datasource) (

--- a/charts/fusion-datasource-monitor/values.yaml
+++ b/charts/fusion-datasource-monitor/values.yaml
@@ -54,8 +54,14 @@ image:
 # Meychele's PRIN-1018 note, not yet product-confirmed per customer (see SRCH-902 for
 # Amex's). Override per-customer in that customer's own values file rather than editing
 # this chart, since different customers may confirm different thresholds.
+#
+# Single alert per namespace (FusionDatasourceCriticalIssue), not per datasource: fires only
+# when at least one datasource meets the `client` (critical) thresholds below; the message body
+# also lists any datasources that only meet the looser `ops` (non-critical) thresholds, so a
+# single notification carries the full picture instead of one alert per failing datasource.
 alerts:
   enabled: false
+  # Non-critical tier - included in a firing alert's message, does not trigger one on its own.
   ops:
     failureCount: 2
     failureWindow: 48h
@@ -63,6 +69,10 @@ alerts:
     # duration literals (e.g. "24h") are only valid inside a range vector selector ([24h]),
     # not in a scalar comparison like `time() - x > N`.
     staleWindowSeconds: 86400 # 24h
+  # Critical tier - at least one datasource meeting these thresholds is what actually fires
+  # and notifies (see templates/rules.yaml for why this alert's own `and` clauses need
+  # `on (namespace, datasource)` - a bare `and` between different `status` label values never
+  # matches in PromQL, a real bug in the original per-datasource design this replaced).
   client:
     failureCount: 4
     failureWindow: 8d


### PR DESCRIPTION
## Summary
Redesigns SRCH-895 alerting per direct feedback: stop sending one alert per failing datasource, aggregate to one alert per namespace, and only notify on critical issues (with non-critical issues included in the message for context).

- **Before**: 4 separate alert rules, each firing one alert instance per datasource that met that rule's condition. On a namespace with several stale/failing datasources, this meant several separate notifications.
- **After**: a single `FusionDatasourceCriticalIssue` alert per namespace. Fires only when ≥1 datasource meets the critical (`client`-tier) thresholds. Its message lists both the critical datasources and any additional non-critical (`ops`-tier) ones currently affected, via Prometheus's `query` annotation function.

## Independent bug found and fixed
While validating this offline with `promtool` (before touching any live cluster), found that the **original** `FusionDatasourceJobFailed`/`FusionDatasourceJobFailedSustained` alerts (shipped in 0.1.3/0.1.4) used a bare `and` between `status="FAILED"` and `status="SUCCESS"` series:
```
increase(fusion_datasource_job_runs_total{status="FAILED"}[48h]) >= 2
and
increase(fusion_datasource_job_runs_total{status="SUCCESS"}[48h]) == 0
```
PromQL's `and`/`unless` match on the **full label set** by default, and these two sides always differ on `status` — so this condition could never match, on any cluster, since it shipped. This went unnoticed because live validation on `lw-docs-config` only ever exercised the Stale family (which has no such issue) — no real failed-run data existed to expose it. Fixed via `and on (namespace, datasource)` everywhere this pattern appears.

## Validation
Entirely offline via `promtool test rules` before any live-cluster changes (deploying even an inert test rule to a live cluster was correctly blocked mid-session as needing explicit authorization, given this exact alerting pipeline caused a real incident earlier in this epic):
- Confirmed `and`/`unless` label-matching behavior in isolation (reproduced the bug, confirmed the `on(...)` fix).
- Confirmed the `query` annotation template function works and can pull in a different metric/condition than the one that triggered the alert.
- Confirmed annotations **cannot** reference sibling annotations (`.Annotations.X` inside another annotation errors) - not assumed, tested and confirmed unsupported, so the message duplicates the query logic directly in `description`.
- Full end-to-end test against realistic synthetic data (3 datasources: one critical via failure count, one critical via staleness, one non-critical) confirms correct aggregation, dedup, and tiering.
- `helm lint` + `helm template` confirm the rendered manifest byte-matches the promtool-validated PromQL.

Bumps chart version 0.1.4 → 0.1.5.

## Test plan
- [x] `promtool test rules` - full aggregation/tiering/dedup logic validated offline
- [x] `helm lint` / `helm template` - rendered output matches validated PromQL exactly
- [ ] Live validation once deployed to a real cluster with `alerts.enabled: true`