### PR TITLE
fusion-datasource-monitor: enrich alert message with context/Fusion/Grafana links

### DIFF
--- a/charts/fusion-datasource-monitor/Chart.yaml
+++ b/charts/fusion-datasource-monitor/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: fusion-datasource-monitor
 sources:
   - https://github.com/lucidworks-managed-fusion/helm-charts.git
-version: 0.1.5
+version: 0.1.6

--- a/charts/fusion-datasource-monitor/templates/rules.yaml
+++ b/charts/fusion-datasource-monitor/templates/rules.yaml
@@ -13,14 +13,20 @@ spec:
       rules:
         # One alert per namespace (not per datasource, not per condition) - fires only when at
         # least one datasource in the namespace is in a critical state. The message embeds both
-        # the critical datasources and any additional non-critical ones currently affected, so
-        # ops gets the full picture in a single notification instead of a flood of individual
-        # per-datasource alerts.
+        # the critical datasources and any additional non-critical ones currently affected, plus
+        # the kube context/Fusion/Grafana links a developer needs to go investigate, so a single
+        # notification carries the full picture instead of one alert per failing datasource.
         #
         # "Critical" = sustained failure (>= client.failureCount failed runs, no success, in
         # client.failureWindow) OR fully stale (no run at all in client.staleWindowSeconds).
         # "Non-critical" = the same conditions at the looser ops thresholds, MINUS anything
         # already counted as critical (so a datasource never appears in both lists).
+        #
+        # project_id/location/cluster are carried through every `count by (...)` below (not just
+        # namespace) so the final alert's own labels can build a literal kube context string
+        # (gke_<project_id>_<location>_<cluster>) - these are GMP-injected on every metric this
+        # exporter emits and are constant within a namespace (one pod per namespace), so keeping
+        # them doesn't change which series get grouped together.
         #
         # NOTE: annotations cannot reference each other (Prometheus's annotation template
         # context has no access to sibling annotations - confirmed via promtool, not assumed),
@@ -34,6 +40,7 @@ spec:
         # shipped in 0.1.3/0.1.4 had this same bug and could never fire, on any cluster - this
         # went unnoticed because live validation only ever exercised the Stale family, which
         # doesn't have this issue).
+        #
         # Named FusionDatasourceJob* (not just "FusionDatasourceCriticalIssue") deliberately -
         # the shared Alertmanager route (SRCH-896) matches `alertname: 'FusionDatasourceJob.*'`,
         # an ANCHORED regex requiring the name to start with "FusionDatasourceJob". Anything else
@@ -42,14 +49,14 @@ spec:
         # before ever renaming this alert again.
         - alert: FusionDatasourceJobCriticalIssue
           expr: |
-            count by (namespace) (
-              count by (namespace, datasource) (
+            count by (namespace, project_id, location, cluster) (
+              count by (namespace, datasource, project_id, location, cluster) (
                 increase(fusion_datasource_job_runs_total{status="FAILED"}[{{ .Values.alerts.client.failureWindow }}]) >= {{ .Values.alerts.client.failureCount }}
                 and on (namespace, datasource)
                 increase(fusion_datasource_job_runs_total{status="SUCCESS"}[{{ .Values.alerts.client.failureWindow }}]) == 0
               )
               or
-              count by (namespace, datasource) (
+              count by (namespace, datasource, project_id, location, cluster) (
                 time() - fusion_datasource_job_last_run_timestamp > {{ .Values.alerts.client.staleWindowSeconds }}
               )
             ) > 0
@@ -59,7 +66,14 @@ spec:
             customer: '{{`{{ $labels.namespace }}`}}'
           annotations:
             summary: "{{`{{ $labels.namespace }}`}} has {{`{{ $value }}`}} datasource(s) in a critical state"
-            description: >-
+            description: |-
               {{`Critical: {{ range query (printf "count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) >= `}}{{ .Values.alerts.client.failureCount }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.client.staleWindowSeconds }}{{`)" $labels.namespace) }}{{ .Labels.datasource }}, {{ end }}`}}
-              {{`Also currently failing (non-critical): {{ range query (printf "(count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.ops.failureWindow }}{{`]) >= `}}{{ .Values.alerts.ops.failureCount }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.ops.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.ops.staleWindowSeconds }}{{`)) unless (count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) >= `}}{{ .Values.alerts.client.failureCount }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.client.staleWindowSeconds }}{{`))" $labels.namespace) }}{{ .Labels.datasource }}, {{ end }}`}}
+              {{`Non-critical: {{ range query (printf "(count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.ops.failureWindow }}{{`]) >= `}}{{ .Values.alerts.ops.failureCount }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.ops.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.ops.staleWindowSeconds }}{{`)) unless (count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) >= `}}{{ .Values.alerts.client.failureCount }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.client.staleWindowSeconds }}{{`))" $labels.namespace) }}{{ .Labels.datasource }}, {{ end }}`}}
+              {{`Kube context: gke_{{ $labels.project_id }}_{{ $labels.location }}_{{ $labels.cluster }}`}}
+              {{- if .Values.alerts.fusionUrl }}
+              Fusion: {{ .Values.alerts.fusionUrl }}
+              {{- end }}
+              {{- if .Values.alerts.grafanaUrl }}
+              Dashboard: {{ .Values.alerts.grafanaUrl }}/d/fusion-datasource-health/datasource-health?var-namespace={{`{{ $labels.namespace }}`}}
+              {{- end }}
 {{- end }}

--- a/charts/fusion-datasource-monitor/values.yaml
+++ b/charts/fusion-datasource-monitor/values.yaml
@@ -55,12 +55,21 @@ image:
 # Amex's). Override per-customer in that customer's own values file rather than editing
 # this chart, since different customers may confirm different thresholds.
 #
-# Single alert per namespace (FusionDatasourceCriticalIssue), not per datasource: fires only
+# Single alert per namespace (FusionDatasourceJobCriticalIssue), not per datasource: fires only
 # when at least one datasource meets the `client` (critical) thresholds below; the message body
 # also lists any datasources that only meet the looser `ops` (non-critical) thresholds, so a
 # single notification carries the full picture instead of one alert per failing datasource.
 alerts:
   enabled: false
+  # Optional per-environment links embedded in the alert message, to speed up triage. Both blank
+  # by default - if unset, that line is simply omitted from the message rather than showing an
+  # empty value. These vary per customer AND per environment (prod vs non-prod have different
+  # hosts), so set them in that environment's own values file, not here.
+  fusionUrl: "" # e.g. "https://amex.b.lucidworks.cloud" - this environment's Fusion UI/API host
+  grafanaUrl: "" # e.g. "https://amex-internal-dashboard-prod.b.lucidworks.cloud" - Grafana host
+  # kube context (gke_<project_id>_<location>_<cluster>) is NOT a value here - it's derived
+  # automatically in templates/rules.yaml from labels GMP already attaches to every metric, so
+  # there's nothing to configure per customer.
   # Non-critical tier - included in a firing alert's message, does not trigger one on its own.
   ops:
     failureCount: 2


### PR DESCRIPTION
## Summary
Enriches the `FusionDatasourceJobCriticalIssue` message per direct feedback on the aggregated alert design (#58):

- **Kube context** (`gke_<project_id>_<location>_<cluster>`) - derived automatically from labels GMP already attaches to every metric. No per-customer config needed.
- **Fusion link** and **Grafana dashboard link** (pre-filtered to the firing namespace via `?var-namespace=`) - both new optional values (`alerts.fusionUrl` / `alerts.grafanaUrl`), since these vary per customer *and* per environment. Omitted from the message entirely when unset, rather than showing an empty line.
- Critical/non-critical datasource lists are now each on their own line instead of folded into one sentence.

## Example rendered message (Amex prod, hypothetical fusionUrl/grafanaUrl set)
```
Summary: amex-prd has 2 datasource(s) in a critical state
Description:
Critical: Web_en_US_CardBenefits_v2, Web_zh_TW,
Non-critical: FAQ_en_US_v2, Web_en_US_NewsRoom_JS,
Kube context: gke_mf-amex_us-west1_lw-amex-prod-us-west1
Fusion: https://amex.b.lucidworks.cloud
Dashboard: https://amex-internal-dashboard-prod.b.lucidworks.cloud/d/fusion-datasource-health/datasource-health?var-namespace=amex-prd
```

## Validation
Offline via `promtool test rules` again before touching any live cluster - specifically confirmed that carrying `project_id`/`location`/`cluster` through every aggregation step (needed for the kube-context annotation) doesn't change which series get grouped together or the datasource count in `summary` (they're constant within a namespace, one pod per namespace).

Bumps chart version 0.1.5 → 0.1.6.

## Test plan
- [x] `promtool test rules` - full aggregation/tiering/label-propagation validated offline
- [x] `helm template` with and without `alerts.fusionUrl`/`alerts.grafanaUrl` set - confirmed lines are correctly present/omitted
- [ ] Live validation once deployed with `alerts.enabled: true` and both URLs configured for a real environment