### PR TITLE
fusion-datasource-monitor: bound staleness with an age ceiling

### DIFF
--- a/charts/fusion-datasource-monitor/Chart.yaml
+++ b/charts/fusion-datasource-monitor/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: fusion-datasource-monitor
 sources:
   - https://github.com/lucidworks-managed-fusion/helm-charts.git
-version: 0.1.6
+version: 0.1.7

--- a/charts/fusion-datasource-monitor/templates/rules.yaml
+++ b/charts/fusion-datasource-monitor/templates/rules.yaml
@@ -18,9 +18,13 @@ spec:
         # notification carries the full picture instead of one alert per failing datasource.
         #
         # "Critical" = sustained failure (>= client.failureCount failed runs, no success, in
-        # client.failureWindow) OR fully stale (no run at all in client.staleWindowSeconds).
+        # client.failureWindow) OR stale within a bounded window (no run in client.staleWindow-
+        # Seconds, but a run recorded within staleMaxAgeSeconds - see that value's comment for
+        # why staleness needs an upper bound, not just a lower one).
         # "Non-critical" = the same conditions at the looser ops thresholds, MINUS anything
-        # already counted as critical (so a datasource never appears in both lists).
+        # already counted as critical (so a datasource never appears in both lists). Datasources
+        # stale beyond staleMaxAgeSeconds appear in NEITHER list - presumed decommissioned/
+        # chronic, not a fresh problem.
         #
         # project_id/location/cluster are carried through every `count by (...)` below (not just
         # namespace) so the final alert's own labels can build a literal kube context string
@@ -39,7 +43,8 @@ spec:
         # promtool: the original per-datasource FusionDatasourceJobFailed/FailedSustained alerts
         # shipped in 0.1.3/0.1.4 had this same bug and could never fire, on any cluster - this
         # went unnoticed because live validation only ever exercised the Stale family, which
-        # doesn't have this issue).
+        # doesn't have this issue). The bare `and` used to bound staleness by age below is fine
+        # without `on(...)` since both sides reference the exact same underlying series/labels.
         #
         # Named FusionDatasourceJob* (not just "FusionDatasourceCriticalIssue") deliberately -
         # the shared Alertmanager route (SRCH-896) matches `alertname: 'FusionDatasourceJob.*'`,
@@ -51,13 +56,15 @@ spec:
           expr: |
             count by (namespace, project_id, location, cluster) (
               count by (namespace, datasource, project_id, location, cluster) (
-                increase(fusion_datasource_job_runs_total{status="FAILED"}[{{ .Values.alerts.client.failureWindow }}]) >= {{ .Values.alerts.client.failureCount }}
+                increase(fusion_datasource_job_runs_total{status="FAILED"}[{{ .Values.alerts.client.failureWindow }}]) >= {{ .Values.alerts.client.failureCount | int64 }}
                 and on (namespace, datasource)
                 increase(fusion_datasource_job_runs_total{status="SUCCESS"}[{{ .Values.alerts.client.failureWindow }}]) == 0
               )
               or
               count by (namespace, datasource, project_id, location, cluster) (
-                time() - fusion_datasource_job_last_run_timestamp > {{ .Values.alerts.client.staleWindowSeconds }}
+                time() - fusion_datasource_job_last_run_timestamp > {{ .Values.alerts.client.staleWindowSeconds | int64 }}
+                and
+                time() - fusion_datasource_job_last_run_timestamp <= {{ .Values.alerts.staleMaxAgeSeconds | int64 }}
               )
             ) > 0
           for: 5m
@@ -67,8 +74,8 @@ spec:
           annotations:
             summary: "{{`{{ $labels.namespace }}`}} has {{`{{ $value }}`}} datasource(s) in a critical state"
             description: |-
-              {{`Critical: {{ range query (printf "count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) >= `}}{{ .Values.alerts.client.failureCount }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.client.staleWindowSeconds }}{{`)" $labels.namespace) }}{{ .Labels.datasource }}, {{ end }}`}}
-              {{`Non-critical: {{ range query (printf "(count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.ops.failureWindow }}{{`]) >= `}}{{ .Values.alerts.ops.failureCount }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.ops.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.ops.staleWindowSeconds }}{{`)) unless (count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) >= `}}{{ .Values.alerts.client.failureCount }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.client.staleWindowSeconds }}{{`))" $labels.namespace) }}{{ .Labels.datasource }}, {{ end }}`}}
+              {{`Critical: {{ range query (printf "count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) >= `}}{{ .Values.alerts.client.failureCount | int64 }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.client.staleWindowSeconds | int64 }}{{` and time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} <= `}}{{ .Values.alerts.staleMaxAgeSeconds | int64 }}{{`)" $labels.namespace) }}{{ .Labels.datasource }}, {{ end }}`}}
+              {{`Non-critical: {{ range query (printf "(count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.ops.failureWindow }}{{`]) >= `}}{{ .Values.alerts.ops.failureCount | int64 }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.ops.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.ops.staleWindowSeconds | int64 }}{{` and time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} <= `}}{{ .Values.alerts.staleMaxAgeSeconds | int64 }}{{`)) unless (count by (namespace, datasource) (increase(fusion_datasource_job_runs_total{status='FAILED', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) >= `}}{{ .Values.alerts.client.failureCount | int64 }}{{` and on (namespace, datasource) increase(fusion_datasource_job_runs_total{status='SUCCESS', namespace='%[1]s'}[`}}{{ .Values.alerts.client.failureWindow }}{{`]) == 0) or count by (namespace, datasource) (time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} > `}}{{ .Values.alerts.client.staleWindowSeconds | int64 }}{{` and time() - fusion_datasource_job_last_run_timestamp{namespace='%[1]s'} <= `}}{{ .Values.alerts.staleMaxAgeSeconds | int64 }}{{`))" $labels.namespace) }}{{ .Labels.datasource }}, {{ end }}`}}
               {{`Kube context: gke_{{ $labels.project_id }}_{{ $labels.location }}_{{ $labels.cluster }}`}}
               {{- if .Values.alerts.fusionUrl }}
               Fusion: {{ .Values.alerts.fusionUrl }}

--- a/charts/fusion-datasource-monitor/values.yaml
+++ b/charts/fusion-datasource-monitor/values.yaml
@@ -70,6 +70,15 @@ alerts:
   # kube context (gke_<project_id>_<location>_<cluster>) is NOT a value here - it's derived
   # automatically in templates/rules.yaml from labels GMP already attaches to every metric, so
   # there's nothing to configure per customer.
+  #
+  # Ceiling on staleness age - beyond this, a datasource is presumed decommissioned/chronic and
+  # stops appearing in either the critical or non-critical list entirely. Staleness alone has no
+  # natural upper bound (a datasource dead for months looks identical to one that just stopped
+  # yesterday), but a months/years-old gap is not a fresh, actionable problem - real data from
+  # Amex non-prod confirmed this: 38 datasources showed as "critical" purely from staleness, and
+  # every single one had been silent for 2+ weeks (most 30-90+ days, several years). First-
+  # iteration default, provisional like the other thresholds below, pending product confirmation.
+  staleMaxAgeSeconds: 1209600 # 14 days
   # Non-critical tier - included in a firing alert's message, does not trigger one on its own.
   ops:
     failureCount: 2


### PR DESCRIPTION
## Summary
Per direct feedback: "datasources and jobs that have failed for months should not be high priority." Staleness previously had no upper bound - `time() - last_run_timestamp > N` stays true forever once a datasource goes quiet, so "just stopped yesterday" and "died two years ago" were indistinguishable.

Confirmed on real Amex non-prod data before making this change: of 38 datasources showing as "critical" purely from staleness, **all** had been silent for 2+ weeks - 2 at 14-30 days, 20 at 30-90 days, 16 at 90+ days (several literally years). None were fresh regressions.

## Change
Adds `alerts.staleMaxAgeSeconds` (default 14 days, provisional like the other thresholds pending product confirmation). Beyond that age, a datasource stops appearing in **either** the critical or non-critical list - presumed decommissioned/chronic, not worth surfacing as a fresh problem.

With this change, today's real Amex non-prod data would produce **zero** critical/non-critical entries instead of 38.

## Bug caught while validating
Interpolating `staleMaxAgeSeconds` without forcing integer formatting rendered as `1.2096e+06` instead of `1209600` (Go's default float formatting for values loaded from untyped YAML) - invalid where PromQL expects a plain number. Fixed by piping all numeric threshold interpolations through `| int64`. Caught via `helm template` inspection before this ever reached `promtool`, let alone a live cluster.

## Validation
Offline via `promtool test rules` against realistic synthetic data:
- A 5-day-old stale datasource (within the new 72h-14d window) → correctly shows as **Critical**
- A 90-day-old stale datasource (beyond the ceiling) → correctly appears in **neither** list
- A 48h-old stale datasource → correctly shows as **Non-critical**

Bumps chart version 0.1.6 → 0.1.7.

## Test plan
- [x] `promtool test rules` - ceiling behavior validated against all three cases
- [x] `helm template` - confirmed plain integer formatting after the `int64` fix
- [ ] Live validation once deployed with `alerts.enabled: true`